### PR TITLE
Mbayly/delegate focus event to behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-node_js: node
+node_js:
+  - "9"
 script:
 - npm run test:lint
 - polymer test --skip-plugin local

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "d2l-colors": "^3.1.2",
-    "d2l-polymer-behaviors": "^1.3.0",
+    "d2l-polymer-behaviors": ">=1.4.0 <2.0",
     "d2l-typography": "^6.1.2",
     "polymer": "1 - 2"
   },

--- a/d2l-text-input.html
+++ b/d2l-text-input.html
@@ -66,7 +66,6 @@ Polymer-based web component for D2L text inputs
 			minlength$="[[minlength]]"
 			name$="[[name]]"
 			on-change="_handleChange"
-			on-focus="_handleFocus"
 			pattern$="[[pattern]]"
 			placeholder$="[[placeholder]]"
 			readonly$="[[readonly]]"
@@ -90,12 +89,6 @@ Polymer-based web component for D2L text inputs
 				 * Fired when the input changes due to user interaction.
 				 *
 				 * @event change
-				*/
-
-				/**
-				 * Fired when the input receives focus.
-				 *
-				 * @event focus
 				*/
 
 				/**
@@ -236,16 +229,6 @@ Polymer-based web component for D2L text inputs
 					this.dispatchEvent(new CustomEvent(
 						'change',
 						{bubbles: true, composed: false}
-					));
-				}
-			},
-			_handleFocus: function() {
-				if (!Polymer.Element && !Polymer.Settings.useShadow) {
-					// This custom focus event is only needed for Polymer 1. We should
-					// be able to remove this event once we move to Polymer 2.
-					this.dispatchEvent(new CustomEvent(
-						'focus',
-						{bubbles: false}
 					));
 				}
 			}

--- a/test/d2l-text-input.html
+++ b/test/d2l-text-input.html
@@ -122,30 +122,20 @@
 
 				});
 
-				describe('focus management', function() {
+				describe('focusable behavior', function() {
 
 					beforeEach(function() {
 						elem = fixture('basic');
 					});
 
-					it('should fire "focus" event when input element is focussed', function(done) {
-						elem.addEventListener('focus', function(e) {
-							expect(e.target).to.equal(elem);
-							done();
-						});
-						MockInteractions.focus(elem.$$('input'));
+					it('should give input element focusable class', function() {
+						expect(elem.$$('input').classList.contains('d2l-focusable'), 'missing d2l-focusable class').to.equal(true);
 					});
 
-					it('should fire "focus" event when custom element is focussed', function(done) {
-						elem.addEventListener('focus', function(e) {
-							expect(e.target).to.equal(elem);
-							done();
-						});
-						MockInteractions.focus(elem);
+					it('includes focusable behavior', function() {
+						expect(elem.behaviors).contains(D2L.PolymerBehaviors.FocusableBehavior);
 					});
-
 				});
-
 			});
 		</script>
 	</body>


### PR DESCRIPTION
I wonder if we should actually just be doing a major version bump here on d2l-polymer-behaviors-ui and d2l-text-input?

Here, I've made it explicit that this version of d2l-text-input depends on versions >= 1.4.0 of d2l-polymer-behaviors, in an attempt to stop people using this version of d2l-text-input with an earlier version of d2l-polymer-behaviors. But it would still be possible for someone to use the previous version of d2l-text-input with v1.4.0 of d2l-polymer-behaviors-ui and they'd get the double events.

But I'm good with the minor bump too.

Because of the more explicit dependency, the build for this PR will fail until we merge/bump d2l-polymer-behaviors-ui. 
https://github.com/Brightspace/d2l-polymer-behaviors-ui/pull/19
(I don't have write permissions in that repo)