### PR TITLE
Set position of input to relative

### DIFF
--- a/d2l-text-input.html
+++ b/d2l-text-input.html
@@ -20,6 +20,7 @@ Polymer-based web component for D2L text inputs
 			}
 
 			input {
+				position: relative;
 				font-family: inherit;
 				@apply --d2l-input;
 			}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,17 +10,17 @@
       "browsers": [
         {
           "browserName": "chrome",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "firefox",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {


### PR DESCRIPTION
We were having issues with the text-input in rubrics creation. When we added the opt-in/out flyout, the user could not click into the text-input (the flyout has 100% height so can be fully viewed in open position). The other input components did not have this problem (textarea, button), and the difference was the relative positioning of those components. See
https://github.com/BrightspaceUI/textarea/blob/master/d2l-textarea.html#L73 and
https://github.com/BrightspaceUI/button/blob/aebdda306fe02b6ee87302e804f9eb6aac1998fd/d2l-button-icon.html#L39
Setting position of input element to relative solves this problem. 

Besides rubrics, it looks like d2l-text-input is currently being used in:
d2l-content-service/app/content/features/purge/
d2l-content-service/app/content/features/search/
course-image-manager/src/course-image-manager-app/views/
But I'm not sure what these are, where to access and test them. Do you guys know?