### PR TITLE
Prevent default browser-supplied validation bubbles

### DIFF
--- a/d2l-text-input.html
+++ b/d2l-text-input.html
@@ -231,6 +231,12 @@ Polymer-based web component for D2L text inputs
 					notify: true
 				}
 			},
+			ready: function() {
+				this.$$('input').addEventListener('invalid', this._handleInvalid.bind(this));
+			},
+			_handleInvalid: function(e) {
+				e.preventDefault();
+			},
 			_handleChange: function() {
 				if (Polymer.Element) {
 					// This custom focus event is only needed for Polymer 1. We should


### PR DESCRIPTION
Browsers will insert default validation bubbles, see https://developer.telerik.com/featured/building-html5-form-validation-bubble-replacements/. This change prevents this. We could make it controlled by a property if the default is desirable for some uses, let me know if that would be preferable. I'll need to make the same update to the textarea component.